### PR TITLE
Fix for case when collective variable is not periodic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # wham
 Python wrapper for Weighted Histogram Analysis Method as implemented by Grossfield et al.
 
-Tested on Version 2.0.9.
+Tested on Version 2.0.9, 2.0.11.
 
 ## Installation
 1. Download WHAM from [here](http://membrane.urmc.rochester.edu/?page_id=126)
 2. Install Python wrapper:
 ```
-pip install git+https://github.com/kbsezginel/wham
+pip install git+https://github.com/bnovak1/wham
 ```
 
 ## Usage
-Currently, the wrapper only supports 1D WHAM calculations but feel free to open an issue or a pull request if you would like 2D WHAM implemented.
+Currently, the wrapper only supports 1D WHAM calculations but feel free to open an issue or a pull
+request if you would like 2D WHAM implemented.
 
-Make sure you check out [WHAM documentation](http://membrane.urmc.rochester.edu/sites/default/files/wham/doc.pdf) before using it. It's fairly short and very informative. All the parameters below would make much more sense after you read it.
-
-Note: Since periodicity is not an optional argument, an empty string should be entered for it if the collective variable is not periodic.
+Make sure you check out
+[WHAM documentation](http://membrane.urmc.rochester.edu/sites/default/files/wham/doc.pdf) before
+using it. It's fairly short and very informative. All the parameters below would make much more
+sense after you read it.
 
 ```python
 from wham import Wham
@@ -33,11 +35,17 @@ W.plot_histograms(title='WHAM histograms', save='wham-hist.png'))
 
 """
 You can run WHAM 1D as follows.
-The input parameters are in the same order as the WHAM executable:
-periodicity of the reaction coordinate, lower and upper boundary of the histogram, number of bins in the histogram, convergence tolerance, temperature at which the WHAM analysis is performed, number of “padding” values that should be printed for periodic PMFs, path to WHAM 1D executable, path to write input and output files for WHAM analysis, cleanup WHAM files after running and finally WHAM verbosity.
+The input parameters are mostly in the same order as the WHAM executable:
+lower and upper boundary of the histogram,
+number of bins in the histogram, convergence tolerance,
+temperature at which the WHAM analysis is performed,
+number of “padding” values that should be printed for periodic PMFs, path to WHAM 1D executable,
+path to write input and output files for WHAM analysis,
+periodicity of the reaction coordinate (defaults to no periodicity),
+cleanup WHAM files after running, and finally WHAM verbosity.
 """
-W.run(periodicity, hist_min, hist_max, num_bins, tolerance, temperature,
-      numpad, executable, directory, cleanup=False, verbose=True)
+W.run(hist_min, hist_max, num_bins, tolerance, temperature,
+      numpad, executable, directory, periodicity='', cleanup=False, verbose=True)
 
 # Finally, you can plot the free energy barrier using the function below
 W.plot_energy_barrier(save='wham-barrier.png'))

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently, the wrapper only supports 1D WHAM calculations but feel free to open 
 
 Make sure you check out [WHAM documentation](http://membrane.urmc.rochester.edu/sites/default/files/wham/doc.pdf) before using it. It's fairly short and very informative. All the parameters below would make much more sense after you read it.
 
+Note: Since periodicity is not an optional argument, an empty string should be entered for it if the collective variable is not periodic.
 
 ```python
 from wham import Wham
@@ -23,7 +24,7 @@ from wham import Wham
 W = Wham()
 """
 Add your simulations with and id, simulation time, position,
-equlibirum position for the spring, and spring constant in kcal/mol
+equilibrium position for the spring, and spring constant in kcal/mol
 """
 W.add_simulation(sim_id, time, position, eq_position, k_spring)
 

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="wham",
-    version="0.1.0",
+    version="0.1.1",
     description="Python wrapper for Weighted Histogram Analysis Method as implemented by Grossfield et al.",
-    author="Kutay B. Sezginel",
-    author_email="kbs37@pitt.edu",
-    url='https://github.com/kbsezginelwham',
+    author="Kutay B. Sezginel, Brian Novak",
+    url='https://github.com/bnovak1/wham',
     include_package_data=True,
     packages=find_packages(),
     install_requires=['numpy'],

--- a/wham/wham.py
+++ b/wham/wham.py
@@ -42,11 +42,11 @@ class Wham:
             Position of the system along the energy barrier during the simulation.
         min_position : float
             Location of the minimum of the biasing potential for this simulation.
-        k_spring : flaot
+        k_spring : float
             Spring constant for the biasing potential used in this simulation.
             Assuming a potential form of V = 0.5k(x - x0)^2.
             The unit should match the unit of the position. For example if position is in Å
-            the spring constant must be in kcal/mol-Å2
+            the spring constant must be in kcal/mol-Å^2
         energy : list or None
             Potential energy of the system during simulation.
             Only used if a temperature is specified.
@@ -56,15 +56,13 @@ class Wham:
                                     'min': min_position, 'k': k_spring,
                                     'energy': energy}
 
-    def run(self, periodicity, hist_min, hist_max, num_bins, tolerance, temperature, numpad,
-            executable, directory, cleanup=False, verbose=True):
+    def run(self, hist_min, hist_max, num_bins, tolerance, temperature, numpad,
+            executable, directory, periodicity='', cleanup=False, verbose=True):
         """
         Run 1D WHAM analysis.
 
         Parameters
         ----------
-        periodicity : str
-            Periodicity of the reaction coordinate.
         hist_min : float
             Lower boundary of the histogram.
         hist_max : float
@@ -81,6 +79,8 @@ class Wham:
             Path to WHAM 1D executable.
         directory : str
             Path to write input and output files for WHAM analysis.
+        periodicity : str (optional , default : '')
+            Periodicity of the reaction coordinate.
         cleanup : bool (optional , default : False)
             Cleanup input files after running WHAM.
         verbose : bool (optional , default : True)

--- a/wham/wham.py
+++ b/wham/wham.py
@@ -105,7 +105,10 @@ class Wham:
         self.args = [executable, periodicity, hist_min, hist_max, num_bins,
                      tolerance, temperature, numpad, data_file, out_file]
 
-        wham_process = subprocess.run(list(map(str, self.args)),
+        # arg_list = [str(arg) for arg in self.args]
+        arg_list = list(map(str, self.args))
+        while '' in arg_list: arg_list.remove('')
+        wham_process = subprocess.run(arg_list,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)
         if verbose:


### PR DESCRIPTION
Since periodicity is not an optional argument, an empty string should be entered for it if the collective variable is not periodic. Having an empty string in the list input to subprocess.run causes a problem. Therefore, remove the empty string from the list.